### PR TITLE
Bump upload-artifacts task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo build --locked --release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifact-${{ matrix.os }}
           path: |
@@ -68,7 +68,7 @@ jobs:
         run: cross build --locked --release --target armv7-unknown-linux-gnueabihf
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifact-cross-build
           path: |


### PR DESCRIPTION
`upload-artifacts@v3` is deprecated, so bump to v4